### PR TITLE
Release 0.3.1 - Fixed seek behaviour edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.1] - 2016-11-14
+### Added
+- File `mode` is now a property.
+
+### Changed
+- seek throws `IOError` if attempting to move before the file beginning.
+
 ## [0.3.0] - 2016-11-09
 ### Added
 - Buffered file/stream interface.
@@ -42,6 +49,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Compilation for python 3 (still not fully working)
 
 [Unreleased]: https://github.com/johan-sports/pyheatshrink/compare/0.3.1...HEAD
+[0.3.1]: https://github.com/johan-sports/pyheatshrink/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/johan-sports/pyheatshrink/compare/0.2.4...0.3.0
 [0.2.4]: https://github.com/johan-sports/pyheatshrink/compare/0.2.3...0.2.4
 [0.2.3]: https://github.com/johan-sports/pyheatshrink/compare/0.2.2...0.2.3

--- a/heatshrink/streams.py
+++ b/heatshrink/streams.py
@@ -187,7 +187,7 @@ class EncodedFile(io.BufferedIOBase):
             raise ValueError("Invalid mode: '{!r}'".format(mode))
 
         if isinstance(filename, (str, bytes, unicode)):
-            self._fp = builtin_open(filename, mode)
+            self._fp = builtin_open(filename, self._mode_str)
             # We opened the file, we need to close it
             self._close_fp = True
         elif hasattr(filename, 'read') or hasattr(filename, 'write'):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='Heatshrink',
-      version='0.3.0',
+      version='0.3.1',
       # Author details
       author='Antonis Kalou @ JOHAN Sports',
       author_email='antonis@johan-sports.com',


### PR DESCRIPTION
For the default python `file` object, if you try and seek before the beginning of the file an `IOError` is thrown

This PR adds this functionality so that this throws `IOError` correctly:

```
with heatshrink.open('test.bin') as fp:
    fp.seek(-10, io.SEEK_CUR)
```